### PR TITLE
🐛 Added prevention for VoiceOver crashes

### DIFF
--- a/Sources/TableView/TableAdapter.swift
+++ b/Sources/TableView/TableAdapter.swift
@@ -476,11 +476,13 @@ extension TableAdapter: UITableViewDelegate {
 
     @available(iOSApplicationExtension 11.0, *)
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard  indexPath.indices.count > 0 else { return nil }
         return selectCellFactory(for: indexPath).leadingSwipeActionsConfigurationInternal(content(at: indexPath))
     }
 
     @available(iOSApplicationExtension 11.0, *)
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard  indexPath.indices.count > 0 else { return nil }
         return selectCellFactory(for: indexPath).trailingSwipeActionsConfigurationInternal(content(at: indexPath))
     }
 

--- a/Sources/TableView/TableAdapter.swift
+++ b/Sources/TableView/TableAdapter.swift
@@ -476,13 +476,13 @@ extension TableAdapter: UITableViewDelegate {
 
     @available(iOSApplicationExtension 11.0, *)
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard  indexPath.indices.count > 0 else { return nil }
+        guard !indexPath.isEmpty else { return nil }
         return selectCellFactory(for: indexPath).leadingSwipeActionsConfigurationInternal(content(at: indexPath))
     }
 
     @available(iOSApplicationExtension 11.0, *)
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard  indexPath.indices.count > 0 else { return nil }
+        guard !indexPath.isEmpty else { return nil }
         return selectCellFactory(for: indexPath).trailingSwipeActionsConfigurationInternal(content(at: indexPath))
     }
 


### PR DESCRIPTION
Apps with iOS 13.1.2 with VoiceOver (accessibility) enabled could crash because UITableView delegate methods are sometimes called with IndexPath without indices.

Added some guard statements that won't modify library logic and prevent crashes.