### PR TITLE
Fixed SPM for Xcode 11 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "ETDataDrivenViewKit",
+    platforms: [.iOS(.v9), .macOS(.v10_10), .watchOS(.v2), .tvOS(.v9)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -14,13 +15,16 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/RxSwiftCommunity/RxDataSources", from: "4.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ETDataDrivenViewKit",
-            path: "Sources"),
+            dependencies: ["Differentiator"],
+            path: "Sources"
+        ),
         .testTarget(
             name: "ETDataDrivenViewKitTests",
             dependencies: ["ETDataDrivenViewKit"]),

--- a/Sources/CollectionView/CollectionAdapter.swift
+++ b/Sources/CollectionView/CollectionAdapter.swift
@@ -104,7 +104,7 @@ open class CollectionAdapter: NSObject {
         let oldSection = [CollectionSection(identity: "dataWrapper", rows: old)]
         let newSection = [CollectionSection(identity: "dataWrapper", rows: new)]
 
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
         }
         if isAnimationDisabledForDeliveryFromEmptyState && deliveredData.isEmpty {

--- a/Sources/TableView/BaseTableAbstractFactory.swift
+++ b/Sources/TableView/BaseTableAbstractFactory.swift
@@ -188,23 +188,23 @@ open class BaseTableAbstractFactory<ContentType, View: UIView>: _BaseTableAbstra
     }
 
     /// Default is nil
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     open func leadingSwipeActionsConfiguration(_ content: ContentType) -> UISwipeActionsConfiguration? {
         return nil
     }
 
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     override func leadingSwipeActionsConfigurationInternal(_ content: Any) -> UISwipeActionsConfiguration? {
         return leadingSwipeActionsConfiguration(typedContent(content)!)
     }
 
     /// Defaults is nil
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     open func trailingSwipeActionsConfiguration(_ content: ContentType) -> UISwipeActionsConfiguration? {
         return nil
     }
 
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     override func trailingSwipeActionsConfigurationInternal(_ content: Any) -> UISwipeActionsConfiguration? {
         return trailingSwipeActionsConfiguration(typedContent(content)!)
     }

--- a/Sources/TableView/TableAdapter.swift
+++ b/Sources/TableView/TableAdapter.swift
@@ -138,7 +138,7 @@ open class TableAdapter: NSObject  {
     // MARK: private
 
     private func deliverData(_ oldSections: [TableSection], _ newSections: [TableSection]) {
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
         }
         if isAnimationDisabledForDeliveryFromEmptyState && deliveredData.isEmpty {
@@ -474,13 +474,13 @@ extension TableAdapter: UITableViewDelegate {
 
     // Swipe actions
 
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard !indexPath.isEmpty else { return nil }
         return selectCellFactory(for: indexPath).leadingSwipeActionsConfigurationInternal(content(at: indexPath))
     }
 
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard !indexPath.isEmpty else { return nil }
         return selectCellFactory(for: indexPath).trailingSwipeActionsConfigurationInternal(content(at: indexPath))

--- a/Sources/TableView/_BaseTableAbstractFactory.swift
+++ b/Sources/TableView/_BaseTableAbstractFactory.swift
@@ -62,12 +62,12 @@ open class _BaseTableAbstractFactory: _BaseAbstractFactory {
         fatalError("Not Implemented")
     }
     
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     func leadingSwipeActionsConfigurationInternal(_ content: Any) -> UISwipeActionsConfiguration? {
         fatalError("Not Implemented")
     }
     
-    @available(iOSApplicationExtension 11.0, *)
+    @available(iOSApplicationExtension 11.0, iOS 11.0, *)
     func trailingSwipeActionsConfigurationInternal(_ content: Any) -> UISwipeActionsConfiguration? {
         fatalError("Not Implemented")
     }

--- a/Sources/Utils/Logger.swift
+++ b/Sources/Utils/Logger.swift
@@ -37,7 +37,7 @@ final class Logger {
     /// output without a configuration change.
     class func debug(_ message: String, _ file: String = #file, _ function: String = #function, line: Int = #line) {
         let l = Log("✅", message, fn: function, line: line, file: file)
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             os_log("%@", log: OSLog(subsystem: subsystem, category: l.fileName), type: .debug, l.description)
         }
     }
@@ -46,7 +46,7 @@ final class Logger {
     /// these logs in memory and moves them to disk when it reaches a limit.
     class func log(_ message: String, _ file: String = #file, _ function: String = #function, line: Int = #line) {
         let l = Log("👉🏻", message, fn: function, line: line, file: file)
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             os_log("%@", log: OSLog(subsystem: subsystem, category: l.fileName), type: .default, l.description)
         }
     }
@@ -56,7 +56,7 @@ final class Logger {
     /// A Fault-level log will cause Info-level logs to move to disk.
     class func info(_ message: String, _ file: String = #file, _ function: String = #function, line: Int = #line) {
         let l = Log("ℹ️", message, fn: function, line: line, file: file)
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             os_log("%@", log: OSLog(subsystem: subsystem, category: l.fileName), type: .info, l.description)
         }
     }
@@ -65,7 +65,7 @@ final class Logger {
     /// system always saves these logs to disk.
     class func error(_ message: String, _ file: String = #file, _ function: String = #function, line: Int = #line) {
         let l = Log("‼️", message, fn: function, line: line, file: file)
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             os_log("%@", log: OSLog(subsystem: subsystem, category: l.fileName), type: .error, l.description)
         }
     }
@@ -74,7 +74,7 @@ final class Logger {
     /// as a device running out of storage. This level is always saved to disk.
     class func fault(_ message: String, _ file: String = #file, _ function: String = #function, line: Int = #line) {
         let l = Log("🛑", message, fn: function, line: line, file: file)
-        if #available(iOSApplicationExtension 10.0, *) {
+        if #available(iOSApplicationExtension 10.0, iOS 10.0, *) {
             os_log("%@", log: OSLog(subsystem: subsystem, category: l.fileName), type: .fault, l.description)
         }
     }


### PR DESCRIPTION
## Co je předmětem tohoto merge requestu

Na základě potřeby použití ETDataDrivenViewKitu v projektu s pomocí SPM jsem opravil konfiguraci balíčku v **Package.swift** a souběžně vyřešil závislost na **RxSwiftCommunity/RxDataSources/Differentiator**.

Následně jsem v rámci tohoto PR opravil makra **@available**, která bránila v sestavení balíčku za použití SPM.

## Prerekvizity testování

- XCode 11.2 a výš

## Speciální požadavky na testování

- Je potřeba prověřit funkčnost přes nejpoužívanější dependency manager (Carthage)
- Je potřeba prověřit funkčnost na starších XCode (pokud někdo využívá)
- Je potřeba prověřit možnost importu na všech cílových platformách (podle konfigurace projektu: iOS, macOS, watchOS a tvOS)

## Důsledky

Tento PR má za následek potřebu instalace toolchainu pro verzi Swiftu 5.0 nebo 5.1 buď instalací nejnovějších XCode nebo přes [odkaz](https://swift.org/download/#releases). 

Pokud by to byla moc velká překážka, tak je možné upravit na `swift-tools-version:4.0`, ale jelikož použití s pomocí SPM nebylo doposud funkční, tak to asi nikoho moc trápit nebude.
